### PR TITLE
fix author url2 in case authors page has url slash disabled

### DIFF
--- a/templates/authors.php
+++ b/templates/authors.php
@@ -38,7 +38,7 @@ $authorLinks = array();
 foreach($authors as $a) {
 	// we set a separate URL (url2) to reflect the public url of the author, since
 	// the author's $author->url is actually a page in the admin
-	$a->url2 = $page->url . $a->name . '/';
+	$a->url2 = rtrim($page->url, '/') . '/' . $a->name . '/';
 	$authorLinks[$a->url2] = $a->get('title|name');
 }
 


### PR DESCRIPTION
when multilang is active you get

/en/authorsadmin/

instead of

/en/authors/admin/ (btw i think one could also remove the trailing slash)

if the authors page has url slash disabled. I  have not checked if this happens in non-multilang setups.
